### PR TITLE
Unifying codepaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Add to your `pom.xml`:
             <goal>generate-sources</goal>
           </goals>
           <configuration>
+            <language>scala</language>
             <specPath>${project.basedir}/src/main/swagger/example-client.yaml</specPath>
             <packageName>com.example.client</packageName>
           </configuration>
@@ -40,10 +41,11 @@ To generate multiple clients, specify multiple `<execution>` sections.
 | Parameter Name | Description |
 |:---------------|:------------|
 | outputPath | Location of generated classes (defaults to `${project.build.directory}/generated-sources/swagger-clients`) |
+| language | Which language to generate (defaults to `java`. Valid values are: `java`, `scala`) |
+| kind | What kind of code should be generated (defaults to `client`. Valid values are: `client`, `server`, `models`) |
 | specPath | Location of the swagger specification file |
 | packageName | Package name to use for the generated classes |
 | dtoPackage | Package name for the data transfer objects (defaults to same as `packageName`) |
 | tracing | Whether or not to generate clients that accept a `TracingContext` which will send tracing headers to the remote service (defaults to `false`) |
-| kind | What kind of code should be generated (defaults to `client`. Valid values are: `client`, `server`, `models`) |
 | customImports | A list of `<customImport>`s that will be added to the top of all generated files. Useful for providing additional typeclass instances or domain-specific types |
 | framework | The framework to generate the code for (defaults to `akka-http`) |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To generate multiple clients, specify multiple `<execution>` sections.
 | Parameter Name | Description |
 |:---------------|:------------|
 | outputPath | Location of generated classes (defaults to `${project.build.directory}/generated-sources/swagger-clients`) |
-| language | Which language to generate (defaults to `java`. Valid values are: `java`, `scala`) |
+| language | Which language to generate (defaults to `scala` currently, will change to `java` in the future. Valid values are: `java`, `scala`) |
 | kind | What kind of code should be generated (defaults to `client`. Valid values are: `client`, `server`, `models`) |
 | specPath | Location of the swagger specification file |
 | packageName | Package name to use for the generated classes |

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <plexus-utils.version>3.2.0</plexus-utils.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scala.version>2.12.8</scala.version>
-    <guardrail.version>0.45.0</guardrail.version>
+    <guardrail.version>0.45.1</guardrail.version>
   </properties>
 
   <profiles>

--- a/src/main/scala/com/twilio/guardrail/AbstractGuardrailCodegenMojo.scala
+++ b/src/main/scala/com/twilio/guardrail/AbstractGuardrailCodegenMojo.scala
@@ -29,7 +29,7 @@ abstract class AbstractGuardrailCodegenMojo(phase: Phase) extends AbstractMojo {
   @Parameter(defaultValue = "${project.build.directory}/generated-sources/guardrail-sources", property = "outputPath", required = true)
   def outputPath: File
 
-  @Parameter(property = "language", defaultValue = "java")
+  @Parameter(property = "language")
   var language: String = _
 
   @Parameter(property = "kind", defaultValue = "client")
@@ -68,6 +68,10 @@ abstract class AbstractGuardrailCodegenMojo(phase: Phase) extends AbstractMojo {
 
 
     try {
+      val _language: String = Option(language).getOrElse({
+        getLog.warn(s"[guardrail-maven-plugin] Default behaviour changing: Please specify <language>scala</language> to maintain the current settings. The default language will change to 'java' in a future release.")
+        "scala"
+      })
       val _kind: CodegenTarget = kind match {
         case "client" => CodegenTarget.Client
         case "server" => CodegenTarget.Server
@@ -88,7 +92,7 @@ abstract class AbstractGuardrailCodegenMojo(phase: Phase) extends AbstractMojo {
 
       getLog.info(s"Generating ${_kind} from ${specPath.getName}")
 
-      guardrailTask(List((language, arg)), outputPath)
+      guardrailTask(List((_language, arg)), outputPath)
     } catch {
       case NonFatal(e) =>
         getLog.error("Failed to generate client", e)


### PR DESCRIPTION
- Adding `language` parameter (defaulting to `java`)
- Unifying driver codepath

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
