### PR TITLE
Allow inheritance

### DIFF
--- a/src/main/scala/com/twilio/guardrail/AbstractGuardrailCodegenMojo.scala
+++ b/src/main/scala/com/twilio/guardrail/AbstractGuardrailCodegenMojo.scala
@@ -57,6 +57,8 @@ abstract class AbstractGuardrailCodegenMojo(phase: Phase) extends AbstractMojo {
   @Parameter(required = false, readonly = false)
   var customImports: java.util.List[_] = _
 
+  protected def cli: CLICommon
+
   override def execute(): Unit = {
     if (!outputPath.exists()) {
       outputPath.mkdirs()
@@ -112,7 +114,7 @@ abstract class AbstractGuardrailCodegenMojo(phase: Phase) extends AbstractMojo {
     }
 
     val (logger, paths) =
-      CLI.guardrailRunner
+      cli.guardrailRunner
         .apply(preppedTasks)
         .fold[List[java.nio.file.Path]]({
           case MissingArg(args, Error.ArgName(arg)) =>

--- a/src/main/scala/com/twilio/guardrail/AbstractGuardrailCodegenMojo.scala
+++ b/src/main/scala/com/twilio/guardrail/AbstractGuardrailCodegenMojo.scala
@@ -1,14 +1,7 @@
 package com.twilio.guardrail
 
-import cats.data.{EitherT, NonEmptyList, WriterT}
-import cats.free.Free
+import cats.data.NonEmptyList
 import cats.implicits._
-import cats.~>
-import com.twilio.guardrail._
-import com.twilio.guardrail.core.CoreTermInterp
-import com.twilio.guardrail.languages.{ ScalaLanguage, LA }
-import com.twilio.guardrail.terms.CoreTerms
-import com.twilio.guardrail.terms.{CoreTerm, CoreTerms, GetDefaultFramework}
 import com.twilio.swagger.core.StructuredLogger._
 import com.twilio.swagger.core.{LogLevel, LogLevels}
 import java.io.File
@@ -118,29 +111,29 @@ abstract class AbstractGuardrailCodegenMojo(phase: Phase) extends AbstractMojo {
         .apply(preppedTasks)
         .fold[List[java.nio.file.Path]]({
           case MissingArg(args, Error.ArgName(arg)) =>
-            println(s"${AnsiColor.RED}Missing argument:${AnsiColor.RESET} ${AnsiColor.BOLD}${arg}${AnsiColor.RESET} (In block ${args})")
+            getLog.error(s"Missing argument: ${AnsiColor.BOLD}${arg}${AnsiColor.RESET} (In block ${args})")
             throw new CodegenFailedException()
           case NoArgsSpecified =>
             List.empty
           case NoFramework =>
-            println(s"${AnsiColor.RED}No framework specified${AnsiColor.RESET}")
+            getLog.error("No framework specified")
             throw new CodegenFailedException()
           case PrintHelp =>
             List.empty
           case UnknownArguments(args) =>
-            println(s"${AnsiColor.RED}Unknown arguments: ${args.mkString(" ")}${AnsiColor.RESET}")
+            getLog.error(s"Unknown arguments: ${args.mkString(" ")}")
             throw new CodegenFailedException()
           case UnparseableArgument(name, message) =>
-            println(s"${AnsiColor.RED}Unparseable argument ${name}: ${message}${AnsiColor.RESET}")
+            getLog.error(s"Unparseable argument ${name}: ${message}")
             throw new CodegenFailedException()
           case UnknownFramework(name) =>
-            println(s"${AnsiColor.RED}Unknown framework specified: ${name}${AnsiColor.RESET}")
+            getLog.error(s"Unknown framework specified: ${name}")
             throw new CodegenFailedException()
           case RuntimeFailure(message) =>
-            println(s"${AnsiColor.RED}Error:${AnsiColor.RESET}${message}")
+            getLog.error(s"Error: ${message}")
             throw new CodegenFailedException()
           case UserError(message) =>
-            println(s"${AnsiColor.RED}Error:${AnsiColor.RESET}${message}")
+            getLog.error(s"Error: ${message}")
             throw new CodegenFailedException()
         }, identity)
         .runEmpty

--- a/src/main/scala/com/twilio/guardrail/GuardrailCodegenMojo.scala
+++ b/src/main/scala/com/twilio/guardrail/GuardrailCodegenMojo.scala
@@ -7,4 +7,6 @@ import org.apache.maven.plugins.annotations.{LifecyclePhase, Mojo, Parameter}
 class GuardrailCodegenMojo extends AbstractGuardrailCodegenMojo(Main) {
   @Parameter(defaultValue = "${project.build.directory}/generated-sources/swagger-clients", property = "outputPath", required = true)
   var outputPath: File = _
+
+  override protected def cli: CLICommon = CLI
 }

--- a/src/main/scala/com/twilio/guardrail/GuardrailTestCodegenMojo.scala
+++ b/src/main/scala/com/twilio/guardrail/GuardrailTestCodegenMojo.scala
@@ -7,4 +7,6 @@ import org.apache.maven.plugins.annotations.{LifecyclePhase, Mojo, Parameter}
 class GuardrailTestCodegenMojo extends AbstractGuardrailCodegenMojo(Test) {
   @Parameter(defaultValue = "${project.build.directory}/generated-sources/swagger-test-clients", property = "outputPath", required = true)
   var outputPath: File = _
+
+  override protected def cli: CLICommon = CLI
 }


### PR DESCRIPTION
Since the only difference between this plugin and a hypothetical (wink) plugin that someone might use to add more frameworks is the `CLICommon` impementation, we can simply make that an abstract method in `AbstractGuardrailCodegenMojo`, and then provide it in the concrete subclasses.  This hypothetical third-party internal plugin could then just extend _this_ plugin's `AbstractGuardrailCodegenMojo` and avoid copy/pasting the entire thing in.

This also cleans up the logging statements to use the maven-provided `Logger` and not `println`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
