### PR TITLE
Use 'property' instead of 'name' for deploy @Parameters

### DIFF
--- a/src/main/scala/com/twilio/guardrail/m2repo/AbstractGuardrailDeployMojo.scala
+++ b/src/main/scala/com/twilio/guardrail/m2repo/AbstractGuardrailDeployMojo.scala
@@ -12,10 +12,10 @@ abstract class AbstractGuardrailDeployMojo extends AbstractMojo {
   protected def `type`: String
   protected def classifier: String
 
-  @Parameter(name = "specPath", required = true)
+  @Parameter(property = "specPath", required = true)
   var specPath: File = _
 
-  @Parameter(name = "guardrail.deploy.skip", defaultValue = "false")
+  @Parameter(property = "guardrail.deploy.skip", defaultValue = "false")
   var skip: Boolean = _
 
   @Parameter(defaultValue = "${project}", required = true, readonly = false)

--- a/src/main/scala/com/twilio/guardrail/m2repo/GuardrailDeployMojo.scala
+++ b/src/main/scala/com/twilio/guardrail/m2repo/GuardrailDeployMojo.scala
@@ -6,15 +6,15 @@ import org.apache.maven.plugins.annotations.{LifecyclePhase, Mojo, Parameter}
 // both the install and deploy stages.
 @Mojo(name = "deploy-openapi-spec", defaultPhase = LifecyclePhase.PACKAGE)
 class GuardrailDeployMojo extends AbstractGuardrailDeployMojo {
-  @Parameter(name = "groupId", defaultValue = "${project.groupId}")
+  @Parameter(property = "groupId", defaultValue = "${project.groupId}")
   var groupId: String = _
 
-  @Parameter(name = "artifactId", defaultValue = "${project.artifactId}")
+  @Parameter(property = "artifactId", defaultValue = "${project.artifactId}")
   var artifactId: String = _
 
-  @Parameter(name = "type", defaultValue = Constants.DEFAULT_TYPE)
+  @Parameter(property = "type", defaultValue = Constants.DEFAULT_TYPE)
   var `type`: String = _
 
-  @Parameter(name = "classifier", defaultValue = Constants.DEFAULT_CLASSIFIER)
+  @Parameter(property = "classifier", defaultValue = Constants.DEFAULT_CLASSIFIER)
   var classifier: String = _
 }


### PR DESCRIPTION
Looks like I used the wrong one, which works most of the time but not all: 'name' is used for bean properties, 'property' is used for the actual property name.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
