### PR TITLE
GitHub CI: enable 'cache' action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,11 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: print Java version
       run: java -version
+    - uses: actions/cache@v1.0.3
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Build with Maven
       run: mvn clean package --file pom.xml


### PR DESCRIPTION
This caches Maven artifacts. Builds should be faster with caching enabled.

See: https://github.com/actions/cache/blob/master/examples.md

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
